### PR TITLE
Adds "Settler" loadout to Wastelander role

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -610,6 +610,7 @@ Raider
 	/datum/outfit/loadout/medic,
 	/datum/outfit/loadout/merchant,
 	/datum/outfit/loadout/scavenger,
+	/datum/outfit/loadout/settler,
 	/datum/outfit/loadout/warrior,
 	/datum/outfit/loadout/ncrcitizen,
 	/datum/outfit/loadout/wastelander_desert_ranger)
@@ -664,6 +665,21 @@ Raider
 							/obj/item/metaldetector=1,
 							/obj/item/shovel=1,
 							/obj/item/gun/ballistic/automatic/pistol/m1911/compact=1)
+
+/datum/outfit/loadout/settler
+	name = "Settler"
+	uniform = /obj/item/clothing/under/f13/settler
+	shoes = /obj/item/clothing/shoes/f13/explorer
+    r_hand = /obj/item/hatchet
+    l_hand = /obj/item/gun/ballistic/automatic/pistol/n99
+    belt = /obj/item/storage/belt
+    backpack_contents = list(/obj/item/stack/sheet/metal=50,
+                            /obj/item/stack/sheet/mineral/wood=50,
+                            /obj/item/pickaxe/mini=1,
+                            /obj/item/toy/crayon/spraycan=1,
+                            /obj/item/cultivator=1,
+                            /obj/item/reagent_containers/glass/bucket=1,
+                            /obj/item/storage/bag/plants/portaseeder=1)
 
 /datum/outfit/loadout/medic
 	name = "Wasteland Doctor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Introduces a new loadout called "Settler" for Wastelanders that focuses on building and farming. To do this, \Fortune13-master\code\modules\jobs\job_types\wasteland.dm was modified to include a new option in the list of Wastelander loadouts.

## Why It's Good For The Game

In Fallout, many characters who can't make it into established factions or towns are doomed to try and survive the wasteland. These Wastelanders, however, are still people who often want stability and safety in their lives, so they commonly take to starting their own homefronts and building whatever habitations they can to survive in peace. These settlers are not currently represented in our loadout options for wastelanders, so I think this addition would give people a new perspective for looking at what they can do as a Wastelander other than just stealing to make a living or trying to wrestle their way into the business of other factions. Plus, it gives raiders somebody else to raid!

## Changelog
:cl:
add: Added the "Settler" loadout for Wastelanders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
